### PR TITLE
Fix: Add missing brace in catch block in EncryptionService

### DIFF
--- a/src/services/encryptionService.ts
+++ b/src/services/encryptionService.ts
@@ -79,7 +79,7 @@ export class EncryptionService {
 
       const decryptedString = this.textDecoder.decode(decryptedBuffer);
       return JSON.parse(decryptedString);
-    } catch (error)
+    } catch (error) { // Added missing opening brace
       // Common error for wrong PIN is "DOMException: OperationError" or similar during decrypt
       console.error("Decryption failed (possibly wrong PIN or corrupted data):", error);
       return null;


### PR DESCRIPTION
- Corrected syntax error in src/services/encryptionService.ts by adding the opening curly brace for the catch block in the decryptData method.

This should resolve the 'Expected { got console' build error.