### PR TITLE
Fix: Stabilize Zustand selector in PinLock.tsx

### DIFF
--- a/src/components/auth/PinLock.tsx
+++ b/src/components/auth/PinLock.tsx
@@ -37,11 +37,7 @@ export function PinLock({ onUnlockSuccess }: PinLockProps) {
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
 
-  // Ensure useAppStore selectors are correctly typed for the new AI config fields
-  const { unlockApp, setDecryptedAiConfig } = useAppStore(state => ({ // Updated to use setDecryptedAiConfig
-    unlockApp: state.unlockApp, // Keep old unlockApp if it's still used elsewhere or phase it out
-    setDecryptedAiConfig: state.setDecryptedAiConfig,
-  }));
+  const setDecryptedAiConfig = useAppStore(state => state.setDecryptedAiConfig); // Select only the needed action
 
 
   useEffect(() => {


### PR DESCRIPTION
Changed the useAppStore selector in PinLock.tsx to directly select the setDecryptedAiConfig action. This aims to prevent potential re-render loops that might have been triggered by an unstable object selector, potentially resolving the "Maximum update depth exceeded" error.